### PR TITLE
Correct bash user variables

### DIFF
--- a/scripts/run_deploy.sh
+++ b/scripts/run_deploy.sh
@@ -21,7 +21,7 @@ openstack-ansible bootstrap-neutron.yml
 popd
 
 pushd ${PROJECT_PATH}/openstack-ansible-ops/elk_metrics_6x
-source bootstrap-embedded-ansible.sh
-ansible-playbook site.yml "${USER_VARS}" -e 'elk_package_state="latest"'
+source bootstrap-embedded-ansible.sh || true
+ansible-playbook site.yml ${USER_VARS} -e 'elk_package_state="latest"'
 deactivate
 popd


### PR DESCRIPTION
The quotes around the user variables option breaks things. This removes
the brokeness.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>